### PR TITLE
Added some conditions which showed errors when missing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "weebly/cloud-client",
+    "name": "amarsyla/cloud-client",
     "description": "Weebly Cloud API library",
     "type": "library",
     "require": {

--- a/src/Utils/CloudClient.php
+++ b/src/Utils/CloudClient.php
@@ -120,7 +120,7 @@ class CloudClient
         $header = substr($result, 0, $header_size);
         $response = substr($result, $header_size);
 
-        if($info['http_code']!=204 && (!$response || json_decode($response)->error)) {
+        if($info['http_code']!=204 && (!$response || !empty(json_decode($response)->error))) {
             $error = json_decode($response)->error;
 
             if($error) {

--- a/src/Utils/CloudResponse.php
+++ b/src/Utils/CloudResponse.php
@@ -84,9 +84,9 @@ class CloudResponse
         preg_match_all("/^X-Resultset-([^:]+): ([\d]+).+$/m", $header, $p);
         $header_fields = array_combine($p[1], $p[2]);
 
-        $this->total = $header_fields['Total'] ?: -1;
-        $this->page_limit = $header_fields['Limit'] ?: -1;
-        $this->page = $header_fields['Page'] ?: -1;
+        $this->total = $header_fields['Total'] ?? -1;
+        $this->page_limit = $header_fields['Limit'] ?? -1;
+        $this->page = $header_fields['Page'] ?? -1;
         $this->page_count = (int) ceil($this->total / $this->page_limit);
         $this->is_paginated = (($this->total) > 0);
         $this->body = $response;


### PR DESCRIPTION
When there are no errors, if using PHP error reporting, it will show an error because `json_encode($error)` is `null`, thus `json_encode($error)->error` doesn't exist.